### PR TITLE
`apt update` warnings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ pgbouncer_stats_users:
 # APT settings
 pgbouncer_apt_key_id: "ACCC4CF8"
 pgbouncer_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
-pgbouncer_apt_repository: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ postgresql_version | default ('') }}"
+pgbouncer_apt_repository: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
 
 
 ###

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ pgbouncer_stats_users:
 # APT settings
 pgbouncer_apt_key_id: "ACCC4CF8"
 pgbouncer_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
-pgbouncer_apt_repository: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+pgbouncer_apt_repository: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ postgresql_version | default ('') }}"
 
 
 ###

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -13,12 +13,6 @@
           changed_when: false
           when: ansible_os_family == "Debian"
 
-        - name: Install gpg-agent
-          apt:
-            name: gpg-agent
-            state: present
-          when: ansible_os_family == "Debian"
-
   roles:
     - role: ansible-role-pgbouncer
       tags:

--- a/tasks/pgbouncer.yml
+++ b/tasks/pgbouncer.yml
@@ -1,15 +1,18 @@
 ---
-- name: Add PgBouncer repository apt-key | apt
-  apt_key:
-    id: "{{ pgbouncer_apt_key_id }}"
-    url: "{{ pgbouncer_apt_key_url }}"
-    state: present
-  when: ansible_os_family == "Debian"
-
-- name: Add PgBouncer repository | apt
-  apt_repository:
-    repo: "{{ pgbouncer_apt_repository }}"
-    state: present
+# This will need replaced with deb822_repository eventually,
+# however module Requires ansible 2.15, ansible pacakage version for Centos7 is 2.9
+- name: Add PgBouncer apt repository | apt
+  block:
+  - name: Add PgBouncer apt-key | apt
+    get_url:
+      url: "{{ pgbouncer_apt_key_url }}"
+      dest: "/etc/apt/trusted.gpg.d/{{ pgbouncer_apt_key_id }}.asc"
+      mode: '0644'
+      force: true
+  - name: Add PgBouncer apt repository | apt
+    apt_repository:
+      repo: "{{ pgbouncer_apt_repository }}"
+      state: present
   when: ansible_os_family == "Debian"
 
 

--- a/tasks/pgbouncer.yml
+++ b/tasks/pgbouncer.yml
@@ -3,16 +3,16 @@
 # however module Requires ansible 2.15, ansible pacakage version for Centos7 is 2.9
 - name: Add PgBouncer apt repository | apt
   block:
-  - name: Add PgBouncer apt-key | apt
-    get_url:
-      url: "{{ pgbouncer_apt_key_url }}"
-      dest: "/etc/apt/trusted.gpg.d/{{ pgbouncer_apt_key_id }}.asc"
-      mode: '0644'
-      force: true
-  - name: Add PgBouncer apt repository | apt
-    apt_repository:
-      repo: "{{ pgbouncer_apt_repository }}"
-      state: present
+    - name: Add PgBouncer apt-key | apt
+      get_url:
+        url: "{{ pgbouncer_apt_key_url }}"
+        dest: "/etc/apt/trusted.gpg.d/{{ pgbouncer_apt_key_id }}.asc"
+        mode: '0644'
+        force: true
+    - name: Add PgBouncer apt repository | apt
+      apt_repository:
+        repo: "{{ pgbouncer_apt_repository }}"
+        state: present
   when: ansible_os_family == "Debian"
 
 


### PR DESCRIPTION
This PR fixes two issues with Warnings during apt upgrade

~~A.   when postgresql is installed via role [miarec/ansible-postgresql](https://github.com/miarec/ansible-postgresql)  apt repository for specific version is added,  example `deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main 12`. This role installs generic version of same repository, this causes the following warnings on `apt-update`~~
```
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:1 and /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:2
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:1 and /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:2
W: Target Translations (main/i18n/Translation-en) is configured multiple times in /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:1 and /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:2
W: Target CNF (main/cnf/Commands-amd64) is configured multiple times in /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:1 and /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:2
W: Target CNF (main/cnf/Commands-all) is configured multiple times in /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:1 and /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:2
```
~~Solution: updated variable `pgbouncer_apt_repository` to insert postgresql version if supplied.~~

This was moved to [miarec/ansible-postgresql](https://github.com/miarec/ansible-postgresql/pull/4)

B. apt-key is installed using deprecated method, causing the following warning on `apt update`; 
```
W: http://apt.postgresql.org/pub/repos/apt/dists/jammy-pgdg/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```
Solution:  now using `get_url` module to install apt-key in `/etc/apt/trusted.gpg.d`    [Reference](https://github.com/ansible/ansible/issues/78063)

NOTE:  ansible module `deb822_repository` can install repository and apt key in one step, however it requires ansible 2.15

